### PR TITLE
Forecast endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/coverage

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 /config/master.key
 
 /coverage
+
+# Ignore application configuration
+/config/application.yml

--- a/app/controllers/api/v1/forecasts_controller.rb
+++ b/app/controllers/api/v1/forecasts_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ForecastsController < ApplicationController
 
   def index
-    render json: ForecastFacade.new(params[:location]).forecast
+    render json: ForecastSerializer.new(ForecastFacade.new(params[:location]).forecast)
   end
 end

--- a/app/controllers/api/v1/forecasts_controller.rb
+++ b/app/controllers/api/v1/forecasts_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::ForecastsController < ApplicationController
+
+  def index
+    render json: ForecastFacade.new(params[:location]).forecast
+  end
+end

--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -7,7 +7,8 @@ class ForecastFacade
     coordinates = mapquest_service.get_coordinates
     # step 2: use the coordinates to get the weather
     forecast = openweather_service(coordinates).get_forecast
-    # step 3: format using the serializer
+    # step 3: create poro
+    Forecast.new(forecast)
   end
 
   private

--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -1,0 +1,21 @@
+class ForecastFacade
+  def initialize(location)
+    @location = location
+  end
+
+  def forecast
+    # step 1: use the location to get the coordinates
+    coordinates = mapquest_service.get_coordinates
+
+    # step 2: use the coordinates to get the weather
+    # step 3: format using the serializer
+  end
+
+  private
+
+  attr_reader :location
+
+  def mapquest_service
+    MapquestService.new(location)
+  end
+end

--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -4,10 +4,9 @@ class ForecastFacade
   end
 
   def forecast
-    # step 1: use the location to get the coordinates
     coordinates = mapquest_service.get_coordinates
-
     # step 2: use the coordinates to get the weather
+    forecast = openweather_service(coordinates).get_forecast
     # step 3: format using the serializer
   end
 
@@ -17,5 +16,9 @@ class ForecastFacade
 
   def mapquest_service
     MapquestService.new(location)
+  end
+
+  def openweather_service(coordinates)
+    OpenweatherService.new(coordinates)
   end
 end

--- a/app/facades/forecast_facade.rb
+++ b/app/facades/forecast_facade.rb
@@ -5,9 +5,7 @@ class ForecastFacade
 
   def forecast
     coordinates = mapquest_service.get_coordinates
-    # step 2: use the coordinates to get the weather
     forecast = openweather_service(coordinates).get_forecast
-    # step 3: create poro
     Forecast.new(forecast)
   end
 

--- a/app/poros/forecast.rb
+++ b/app/poros/forecast.rb
@@ -1,0 +1,77 @@
+class Forecast
+
+  attr_reader :id,
+              :current_weather,
+              :daily_weather,
+              :hourly_weather
+
+  def initialize(forecast_info)
+    @id = nil
+    @current_weather = format_current_weather(forecast_info["current"])
+    @daily_weather = format_daily_weather(forecast_info["daily"])
+    @hourly_weather = format_hourly_weather(forecast_info["hourly"])
+  end
+
+  private
+  def format_current_weather(info)
+    {
+      datetime: Time.at(info["dt"]).to_s,
+      sunrise: Time.at(info["sunrise"]).to_s,
+      sunset: Time.at(info["sunset"]).to_s,
+      temperature: info["temp"],
+      feels_like: info["feels_like"],
+      humidity: info["humidity"],
+      uvi: info["uvi"],
+      visibility: info["visibility"],
+      conditions: info["weather"].first["description"],
+      icon: info["weather"].first["icon"]
+    }
+  end
+
+  def format_daily_weather(info)
+    info[0..4].map do |day|
+      {
+        date: Time.at(day["dt"]).to_date.to_s,
+        sunrise: Time.at(day["sunrise"]).to_s,
+        sunset: Time.at(day["sunset"]).to_s,
+        max_temp: day["temp"]["max"],
+        min_temp: day["temp"]["min"],
+        conditions: day["weather"].first["description"],
+        icon: day["weather"].first["icon"]
+      }
+    end
+  end
+
+  def format_hourly_weather(info)
+    info[0..7].map do |hour|
+      {
+        time: Time.at(hour["dt"]).strftime("%H:%M:%S"),
+        temperature: hour["temp"],
+        wind_speed: hour["wind_speed"].to_s + " mph",
+        wind_direction: convert_to_wind_direction(hour["wind_deg"]),
+        conditions: hour["weather"].first["description"],
+        icon: hour["weather"].first["icon"]
+      }
+    end
+  end
+
+  def convert_to_wind_direction(degree)
+    if degree >= 22.5 && degree < 67.5
+      'North Easterly'
+    elsif degree >= 67.5 && degree < 112.5
+      'Easterly'
+    elsif degree >= 122.5 && degree < 157.5
+      'South Easterly'
+    elsif degree >= 157.5 && degree < 202.5
+      'Southerly'
+    elsif degree >= 202.5 && degree < 247.5
+      'South Westerly'
+    elsif degree >= 247.5 && degree < 292.5
+      'Westerly'
+    elsif degree >= 292.5 && degree < 337.5
+      'North Westerly'
+    else
+      'Northerly'
+    end
+  end
+end

--- a/app/poros/forecast.rb
+++ b/app/poros/forecast.rb
@@ -12,14 +12,13 @@ class Forecast
     @hourly_weather = format_hourly_weather(forecast_info["hourly"])
   end
 
-  private
   def format_current_weather(info)
     {
       datetime: Time.at(info["dt"]).to_s,
       sunrise: Time.at(info["sunrise"]).to_s,
       sunset: Time.at(info["sunset"]).to_s,
-      temperature: info["temp"],
-      feels_like: info["feels_like"],
+      temperature: convert_kelvin_to_fahrenheit(info["temp"]),
+      feels_like: convert_kelvin_to_fahrenheit(info["feels_like"]),
       humidity: info["humidity"],
       uvi: info["uvi"],
       visibility: info["visibility"],
@@ -34,8 +33,8 @@ class Forecast
         date: Time.at(day["dt"]).to_date.to_s,
         sunrise: Time.at(day["sunrise"]).to_s,
         sunset: Time.at(day["sunset"]).to_s,
-        max_temp: day["temp"]["max"],
-        min_temp: day["temp"]["min"],
+        max_temp: convert_kelvin_to_fahrenheit(day["temp"]["max"]),
+        min_temp: convert_kelvin_to_fahrenheit(day["temp"]["min"]),
         conditions: day["weather"].first["description"],
         icon: day["weather"].first["icon"]
       }
@@ -46,7 +45,7 @@ class Forecast
     info[0..7].map do |hour|
       {
         time: Time.at(hour["dt"]).strftime("%H:%M:%S"),
-        temperature: hour["temp"],
+        temperature: convert_kelvin_to_fahrenheit(hour["temp"]),
         wind_speed: hour["wind_speed"].to_s + " mph",
         wind_direction: convert_to_wind_direction(hour["wind_deg"]),
         conditions: hour["weather"].first["description"],
@@ -73,5 +72,11 @@ class Forecast
     else
       'Northerly'
     end
+  end
+
+  def convert_kelvin_to_fahrenheit(kelvin_temp)
+    celsius_temp = kelvin_temp - 273.15
+    fahrenheit = celsius_temp * (9/5) + 32
+    fahrenheit.round(2)
   end
 end

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,0 +1,7 @@
+class ForecastSerializer
+  include FastJsonapi::ObjectSerializer
+  set_id :id
+  attributes :current_weather,
+             :daily_weather,
+             :hourly_weather
+end

--- a/app/services/mapquest_service.rb
+++ b/app/services/mapquest_service.rb
@@ -1,0 +1,18 @@
+class MapquestService
+  def initialize(location)
+    @location = location
+  end
+
+  def get_coordinates
+    response = conn.get("/geocoding/v1/address?key=#{ENV["MAPQUEST_KEY"]}&location=#{location}")
+    JSON.parse(response.body)["results"].first["locations"].first["latLng"]
+  end
+
+  private
+
+  attr_reader :location
+
+  def conn
+    Faraday.new(url: "http://www.mapquestapi.com")
+  end
+end

--- a/app/services/openweather_service.rb
+++ b/app/services/openweather_service.rb
@@ -1,0 +1,20 @@
+class OpenweatherService
+  def initialize(coordinates)
+    @lat = coordinates["lat"]
+    @lng = coordinates["lng"]
+  end
+
+  def get_forecast
+    response = conn.get("/data/2.5/onecall?lat=#{lat}&lon=#{lng}&exclude=minutely,alerts&appid=#{ENV["OPENWEATHER_KEY"]}")
+    JSON.parse(response.body)
+  end
+
+  private
+
+  attr_reader :lat,
+              :lng
+
+  def conn
+    Faraday.new(url: "https://api.openweathermap.org")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  namespace :api do
+    namespace :v1 do
+      get '/forecast', to: 'forecasts#index'
+    end
+  end
 end

--- a/spec/facades/forecast_facade_spec.rb
+++ b/spec/facades/forecast_facade_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe ForecastFacade do
+  describe 'Instance Methods' do
+    describe '#forecast' do
+      it 'uses services to create a forecast' do
+        facade = ForecastFacade.new('Denver, CO')
+
+        actual = facade.forecast
+        expect(actual).to be_a(Forecast)
+        expect(actual.id).to be nil
+      end
+    end
+  end
+end

--- a/spec/poros/forecast_spec.rb
+++ b/spec/poros/forecast_spec.rb
@@ -1,0 +1,262 @@
+require 'rails_helper'
+
+describe Forecast do
+  before :each do
+    forecast_info = {
+      "lat" => 39.7385,
+      "lon" => -104.9849,
+      "timezone" => "America/Denver",
+      "timezone_offset" => -25200,
+      "current" => {
+        "dt" => 1610994697,
+        "sunrise" => 1610979458,
+        "sunset" => 1611014575,
+        "temp" => 275.09,
+        "feels_like" => 271.29,
+        "pressure" => 1018,
+        "humidity" => 49,
+        "dew_point" => 266.36,
+        "uvi" => 1.96,
+        "clouds" => 18,
+        "visibility" => 10000,
+        "wind_speed" => 1.34,
+        "wind_deg" => 351,
+        "wind_gust" => 3.58,
+        "weather" => [
+          {
+            "id" => 801,
+            "main" => "Clouds",
+            "description" => "few clouds",
+            "icon" => "02d"
+          }
+        ]
+      },
+     "hourly" => [
+        {
+          "dt" => 1610992800,
+          "temp" => 275.09,
+          "feels_like" => 271.71,
+          "pressure" => 1018,
+          "humidity" => 49,
+          "dew_point" => 266.36,
+          "uvi" => 1.83,
+          "clouds" => 18,
+          "visibility" => 10000,
+          "wind_speed" => 0.74,
+          "wind_deg" => 88,
+          "weather" => [
+            {
+              "id" => 801,
+               "main" => "Clouds",
+               "description" => "few clouds",
+               "icon" => "02d"
+            }
+          ],
+          "pop" => 0
+        }
+      ],
+      "daily" => [
+        {
+          "dt" => 1610996400,
+          "sunrise" => 1610979458,
+          "sunset" => 1611014575,
+          "temp" => {
+            "day" => 275.9,
+            "min" => 271.18,
+            "max" => 278.69,
+            "night" => 271.18,
+            "eve" => 275.2,
+            "morn" => 273.06
+          },
+          "feels_like" => {
+            "day" => 272.86,
+            "night" => 267.38,
+            "eve" => 268.13,
+            "morn" => 270.41
+          },
+          "pressure" => 1018,
+          "humidity" => 57,
+          "dew_point" => 268.8,
+          "wind_speed" => 0.63,
+          "wind_deg" => 225,
+          "weather" => [
+            {
+              "id" => 800,
+              "main" => "Clear",
+              "description" => "clear sky", "icon" => "01d"
+            }
+          ],
+          "clouds" => 9,
+          "pop" => 0.23,
+          "uvi" => 1.96
+        }
+      ]
+    }
+
+    @forecast = Forecast.new(forecast_info)
+  end
+
+  describe 'Instance Methods' do
+    describe '#format_current_weather' do
+      it 'formats the current weather' do
+        current_weather_info = {
+          "dt" => 1610994697,
+          "sunrise" => 1610979458,
+          "sunset" => 1611014575,
+          "temp" => 275.09,
+          "feels_like" => 271.29,
+          "pressure" => 1018,
+          "humidity" => 49,
+          "dew_point" => 266.36,
+          "uvi" => 1.96,
+          "clouds" => 18,
+          "visibility" => 10000,
+          "wind_speed" => 1.34,
+          "wind_deg" => 351,
+          "wind_gust" => 3.58,
+          "weather" => [
+            {
+              "id" => 801,
+              "main" => "Clouds",
+              "description" => "few clouds",
+              "icon" => "02d"
+            }
+          ]
+        }
+
+        expected = {
+          datetime: "2021-01-18 10:31:37 -0800",
+          sunrise: "2021-01-18 06:17:38 -0800",
+          sunset: "2021-01-18 16:02:55 -0800",
+          temperature: 33.94,
+          feels_like: 30.14,
+          humidity: 49,
+          uvi: 1.96,
+          visibility: 10000,
+          conditions: "few clouds",
+          icon: "02d"
+        }
+
+        expect(@forecast.format_current_weather(current_weather_info)).to eq(expected)
+      end
+    end
+
+    describe '#format_daily_weather' do
+      it 'formats daily weather' do
+        one_day_weather_info = {
+          "dt" => 1610996400,
+          "sunrise" => 1610979458,
+          "sunset" => 1611014575,
+          "temp" => {
+            "day" => 275.9,
+            "min" => 271.18,
+            "max" => 278.69,
+            "night" => 271.18,
+            "eve" => 275.2,
+            "morn" => 273.06},
+          "feels_like" => {
+            "day" => 272.86,
+            "night" => 267.38,
+            "eve" => 268.13,
+            "morn" => 270.41
+          },
+          "pressure" => 1018,
+          "humidity" => 57,
+          "dew_point" => 268.8,
+          "wind_speed" => 0.63,
+          "wind_deg" => 225,
+          "weather" => [
+            {
+              "id" => 800,
+              "main" => "Clear",
+              "description" => "clear sky",
+              "icon" => "01d"
+            }
+          ],
+          "clouds" => 9,
+          "pop" => 0.23,
+          "uvi" => 1.96
+        }
+        daily_weather_info = []
+        8.times do
+          daily_weather_info << one_day_weather_info
+        end
+
+        expected_single_day = {
+          date: "2021-01-18",
+          sunrise: "2021-01-18 06:17:38 -0800",
+          sunset: "2021-01-18 16:02:55 -0800",
+          max_temp: 37.54,
+          min_temp: 30.03,
+          conditions: "clear sky",
+          icon: "01d"
+        }
+        actual = @forecast.format_daily_weather(daily_weather_info)
+        expect(actual.count).to eq(5)
+        expect(actual.first).to eq(expected_single_day)
+      end
+    end
+
+    describe '#format_hourly_weather' do
+      it 'formats hourly weather' do
+        one_hour_weather_info = {
+          "dt" => 1610992800,
+          "temp" => 275.09,
+          "feels_like" => 271.71,
+          "pressure" => 1018,
+          "humidity" => 49,
+          "dew_point" => 266.36,
+          "uvi" => 1.83,
+          "clouds" => 18,
+          "visibility" => 10000,
+          "wind_speed" => 0.74,
+          "wind_deg" => 88,
+          "weather" => [
+            {
+              "id" => 801,
+              "main" => "Clouds",
+              "description" => "few clouds",
+              "icon" => "02d"
+            }
+          ],
+          "pop" => 0
+        }
+        hourly_weather_info = []
+        12.times do
+          hourly_weather_info << one_hour_weather_info
+        end
+
+        expected_single_hour = {
+          time: "10:00:00",
+          temperature: 33.94,
+          wind_speed: "0.74 mph",
+          wind_direction: "Easterly",
+          conditions: "few clouds",
+          icon: "02d"
+        }
+        actual = @forecast.format_hourly_weather(hourly_weather_info)
+        expect(actual.count).to eq(8)
+        expect(actual.first).to eq(expected_single_hour)
+      end
+    end
+
+    describe '#convert_to_wind_direction' do
+      it 'takes degrees and turns it into a direction string' do
+        expect(@forecast.convert_to_wind_direction(23)).to eq('North Easterly')
+        expect(@forecast.convert_to_wind_direction(68)).to eq('Easterly')
+        expect(@forecast.convert_to_wind_direction(123)).to eq('South Easterly')
+        expect(@forecast.convert_to_wind_direction(158)).to eq('Southerly')
+        expect(@forecast.convert_to_wind_direction(203)).to eq('South Westerly')
+        expect(@forecast.convert_to_wind_direction(248)).to eq('Westerly')
+        expect(@forecast.convert_to_wind_direction(293)).to eq('North Westerly')
+        expect(@forecast.convert_to_wind_direction(0)).to eq('Northerly')
+      end
+    end
+
+    describe '#convert_kelvin_to_fahrenheit' do
+      it 'converts kelvin to F' do
+        expect(@forecast.convert_kelvin_to_fahrenheit(364)).to eq(122.85)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/forecast_request_spec.rb
+++ b/spec/requests/api/v1/forecast_request_spec.rb
@@ -38,8 +38,8 @@ describe 'Forecast API' do
     expect(response_body[:attributes][:current_weather][:temperature]).to be_a(Float)
     expect(response_body[:attributes][:current_weather][:feels_like]).to be_a(Float)
     expect(response_body[:attributes][:current_weather][:humidity].class).to be_in([Float, Integer])
-    expect(response_body[:attributes][:current_weather][:uvi]).to be_in([Float, Integer])
-    expect(response_body[:attributes][:current_weather][:visibvisibility]).to be_in([Float, Integer])
+    expect(response_body[:attributes][:current_weather][:uvi].class).to be_in([Float, Integer])
+    expect(response_body[:attributes][:current_weather][:visibility].class).to be_in([Float, Integer])
     expect(response_body[:attributes][:current_weather][:conditions]).to be_a(String)
     expect(response_body[:attributes][:current_weather][:icon]).to be_a(String)
 

--- a/spec/requests/api/v1/forecast_request_spec.rb
+++ b/spec/requests/api/v1/forecast_request_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+describe 'Forecast API' do
+  it 'gets weather for a city' do
+    get '/api/v1/forecast?location=denver,co'
+
+    expect(response).to be_successful
+    response_body = JSON.parse(response.body, symbolize_names: true)[:data]
+
+    expect(response_body).to be_a(Hash)
+    expect(response_body[:attributes][:current_weather]).to be_a(Hash)
+    expect(response_body[:attributes][:daily_weather]).to be_a(Array)
+    expect(response_body[:attributes][:hourly_weather]).to be_a(Array)
+
+    expect(response_body[:type]).to be_a(String)
+    expect(response_body[:id]).to be nil
+    expect(response_body.keys).to eq([:id, :type, :attributes])
+    expect(response_body[:attributes].keys).to eq([:current_weather, :daily_weather, :hourly_weather])
+
+    expected_current_weather_keys = [
+      :datetime,
+      :sunrise,
+      :sunset,
+      :temperature,
+      :feels_like,
+      :humidity,
+      :uvi,
+      :visibility,
+      :conditions,
+      :icon
+    ]
+
+    expect(response_body[:attributes][:current_weather].keys).to eq(expected_current_weather_keys)
+
+    expect(response_body[:attributes][:current_weather][:datetime]).to be_a(String)
+    expect(response_body[:attributes][:current_weather][:sunrise]).to be_a(String)
+    expect(response_body[:attributes][:current_weather][:sunset]).to be_a(String)
+    expect(response_body[:attributes][:current_weather][:temperature]).to be_a(Float)
+    expect(response_body[:attributes][:current_weather][:feels_like]).to be_a(Float)
+    expect(response_body[:attributes][:current_weather][:humidity].class).to be_in([Float, Integer])
+    expect(response_body[:attributes][:current_weather][:uvi]).to be_in([Float, Integer])
+    expect(response_body[:attributes][:current_weather][:visibvisibility]).to be_in([Float, Integer])
+    expect(response_body[:attributes][:current_weather][:conditions]).to be_a(String)
+    expect(response_body[:attributes][:current_weather][:icon]).to be_a(String)
+
+    expected_daily_weather_keys = [
+      :date,
+      :sunrise,
+      :sunset,
+      :max_temp,
+      :min_temp,
+      :conditions,
+      :icon
+    ]
+
+    expect(response_body[:attributes][:daily_weather].count).to eq(5)
+    expect(response_body[:attributes][:daily_weather].first.keys).to eq(expected_daily_weather_keys)
+
+    expect(response_body[:attributes][:daily_weather].first[:date]).to be_a(String)
+    expect(response_body[:attributes][:daily_weather].first[:sunrise]).to be_a(String)
+    expect(response_body[:attributes][:daily_weather].first[:sunset]).to be_a(String)
+    expect(response_body[:attributes][:daily_weather].first[:max_temp]).to be_a(Float)
+    expect(response_body[:attributes][:daily_weather].first[:min_temp]).to be_a(Float)
+    expect(response_body[:attributes][:daily_weather].first[:conditions]).to be_a(String)
+    expect(response_body[:attributes][:daily_weather].first[:icon]).to be_a(String)
+
+    expected_hourly_weather_keys = [
+      :time,
+      :temperature,
+      :wind_speed,
+      :wind_direction,
+      :conditions,
+      :icon
+    ]
+
+    expect(response_body[:attributes][:hourly_weather].count).to eq(8)
+    expect(response_body[:attributes][:hourly_weather].first.keys).to eq(expected_hourly_weather_keys)
+
+    expect(response_body[:attributes][:hourly_weather].first[:time]).to be_a(String)
+    expect(response_body[:attributes][:hourly_weather].first[:temperature]).to be_a(Float)
+    expect(response_body[:attributes][:hourly_weather].first[:wind_speed]).to be_a(String)
+    expect(response_body[:attributes][:hourly_weather].first[:wind_direction]).to be_a(String)
+    expect(response_body[:attributes][:hourly_weather].first[:conditions]).to be_a(String)
+    expect(response_body[:attributes][:hourly_weather].first[:icon]).to be_a(String)
+  end
+end

--- a/spec/services/mapquest_service_spec.rb
+++ b/spec/services/mapquest_service_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe MapquestService do
+  describe 'Instance Methods' do
+    describe 'get_coordinates' do
+      it 'uses location to get coordinates' do
+        service = MapquestService.new('Denver, CO')
+
+        expected = {
+          "lat" => 39.738453,
+          "lng" => -104.984853
+        }
+
+        expect(service.get_coordinates).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/services/openweather_service_spec.rb
+++ b/spec/services/openweather_service_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe OpenweatherService do
+  describe 'Instance Methods' do
+    describe 'get_forecast' do
+      it 'uses coordinates to get forecast' do
+        coordinates = {
+          "lat" => 39.738453,
+          "lng" => -104.984853
+        }
+
+        service = OpenweatherService.new(coordinates)
+
+        expected_headers = [
+          'lat',
+          'lon',
+          'timezone',
+          'timezone_offset',
+          'current',
+          'hourly',
+          'daily',
+        ]
+
+        expect(service.get_forecast).to be_a(Hash)
+        expect(service.get_forecast.keys).to eq(expected_headers)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Commits

Initial setup
- Add coverage
- Write test for forecast endpoint

Get mapquest key
- Figaro install
    - creates `application.yml` file to "hide" `MAPQUEST_API`

Collect data from apis
- Get coordinates from mapquest api
- Get forecast from openweather api

Build a forecast response and include only necessary attributes
- Create forecast PORO
- Remove comments
- Test Forecast instance methods
- Test forecast facade
- Test services

### Description
This PR merges the `forecast-endpoint` branch, and the code in this branch returns a response that pulls data from the mapquest api and openweather api to display a current, daily, and hourly forecast.

### Issue(s) Closed
- None created

### How Has This Been Tested?
- Types of spec: facades, poros, requests, and services
- All tests passing
- `Simplecov` at 100%

Screenshots (if applicable):
<img width="1253" alt="passing tests" src="https://user-images.githubusercontent.com/46658858/104978830-a52cdc80-59b7-11eb-9238-64dabe759ad4.png">