### PR TITLE
Create users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'puma', '~> 3.11'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
+    bcrypt (3.1.16)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -172,6 +173,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
   faraday

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,8 +1,7 @@
 class Api::V1::UsersController < ApplicationController
   def create
-    # binding.pry
     user = User.new(user_params)
-    user.api_key = rand(27)
+    user.api_key = generate_api_key
     if user.save
       render json: UserSerializer.new(user), status: 201
     else
@@ -15,5 +14,15 @@ class Api::V1::UsersController < ApplicationController
 
   def user_params
     params.permit(:email, :password, :password_confirmation)
+  end
+
+  def generate_api_key
+    api_key = rand(27)
+    existing_user = User.find_by(api_key: api_key)
+    while existing_user.present?
+      api_key = rand(27)
+      existing_user = User.find_by(api_key: api_key)
+    end
+    api_key
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+    # binding.pry
+    user = User.new(user_params)
+    user.api_key = rand(27)
+    if user.save
+      render json: UserSerializer.new(user), status: 201
+    else
+      messages = user.errors.full_messages.to_sentence
+      render json: { messages: messages }, status: 400
+    end
+  end
+
+  private
+
+  def user_params
+    params.permit(:email, :password, :password_confirmation)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,5 @@
+class User < ApplicationRecord
+  has_secure_password
+  validates_presence_of :email
+  validates_uniqueness_of :email
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,6 @@
+class UserSerializer
+  include FastJsonapi::ObjectSerializer
+  set_id :id
+  attributes :email,
+             :api_key
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/forecast', to: 'forecasts#show'
       get '/backgrounds', to: 'backgrounds#show'
+      post '/users', to: 'users#create'
     end
   end
 end

--- a/db/migrate/20210120033851_create_users.rb
+++ b/db/migrate/20210120033851_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+      t.string :api_key
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_01_20_033851) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.string "api_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+describe User, type: :model do
+  describe "validations" do
+    it {should have_secure_password}
+    it {should validate_presence_of(:email)}
+    it {should validate_presence_of(:password)}
+    it {should validate_uniqueness_of(:email)}
+    it { should validate_confirmation_of :password }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
 end

--- a/spec/requests/api/v1/create_user_request_spec.rb
+++ b/spec/requests/api/v1/create_user_request_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+describe 'Users API' do
+  it 'can create a user' do
+    body = {
+      email: "whatever@example.com",
+      password: "password",
+      password_confirmation: "password"
+    }
+    post '/api/v1/users', params: body, as: :json
+
+    expect(response).to be_successful
+    expect(response.status).to eq(201)
+
+    response_body = JSON.parse(response.body, symbolize_names: true)[:data]
+
+    expect(response_body[:type]).to eq('user')
+    expect(response_body[:id].to_i).to be_a(Integer)
+    expect(response_body[:attributes][:email]).to eq(body[:email])
+    expect(response_body[:attributes][:api_key]).to be_a(String)
+
+    expect(User.last.email).to eq(body[:email])
+    expect(User.last.api_key).to_not be nil
+  end
+
+  context 'if passwords dont match' do
+    it 'will send a 400 status code and a reason' do
+      body = {
+        email: "whatever@example.com",
+        password: "password",
+        password_confirmation: "passwgyjkord"
+      }
+      post '/api/v1/users', params: body, as: :json
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(400)
+
+      response_body = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response_body[:messages]).to eq("Password confirmation doesn't match Password")
+    end
+  end
+
+  context 'if email has already been taken' do
+    it 'will send a 400 status code and a reason' do
+      user = User.create!(email: 'whatever@example.com', password: 'password')
+
+      body = {
+        email: user.email,
+        password: "password",
+        password_confirmation: "password"
+      }
+
+      post '/api/v1/users', params: body, as: :json
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(400)
+
+      response_body = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response_body[:messages]).to eq("Email has already been taken")
+    end
+  end
+
+  context 'if a field is missing' do
+    it 'will send a 400 status code and a reason' do
+      body = {
+        email: "whatever@example.com",
+        password: "password",
+        password_confirmation: ""
+      }
+
+      post '/api/v1/users', params: body, as: :json
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(400)
+
+      response_body = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response_body[:messages]).to eq("Password confirmation doesn't match Password")
+    end
+  end
+end


### PR DESCRIPTION
### Commits

Create user table migrations and model, and adds an endpoint to create a user
- Add bcrypt
- Add Shoulda Matchers
- Creating user model
- Add create user endpoint

### Description
This PR adds the functionality that allows the frontend to create a user. Users are stored in the database with a unique API key that can be used to call on that user in future requests. Emails must be unique and passwords must match password confirmation.

### Issue(s) Closed
None created

### How Has This Been Tested?
Types of spec: model, request

All tests passing
Simplecov at 100%

Screenshots (if applicable):